### PR TITLE
Missing changes for rebranding/migration to OpenFE

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: codecov
         if: ${{ github.repository == 'OpenFreeEnergy/feflow'
                 && github.event_name == 'pull_request' }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: coverage.xml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,7 +85,7 @@ jobs:
               pytest -n auto -v --cov=feflow --cov-report=xml --durations=10
 
       - name: codecov
-        if: ${{ github.repository == 'choderalab/feflow'
+        if: ${{ github.repository == 'OpenFreeEnergy/feflow'
                 && github.event_name == 'pull_request' }}
         uses: codecov/codecov-action@v3
         with:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,6 +26,6 @@ authors:
   - given-names: Michael M.
     family-names: Henry
     orcid: 'https://orcid.org/0000-0002-3870-9993'
-repository-code: 'https://github.com/choderalab/feflow'
+repository-code: 'https://github.com/OpenFreeEnergy/feflow'
 version: '0.1'
 date-released: '2024-07-29'

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 FE Flow
 ==============================
 [//]: # (Badges)
-[![GitHub Actions Build Status](https://github.com/choderalab/feflow/actions/workflows/ci.yaml/badge.svg)](https://github.com/choderalab/feflow/actions/workflows/ci.yaml)
-[![codecov](https://codecov.io/gh/choderalab/feflow/branch/main/graph/badge.svg)](https://codecov.io/gh/choderalab/feflow/branch/main)
+[![GitHub Actions Build Status](https://github.com/OpenFreeEnergy/feflow/actions/workflows/ci.yaml/badge.svg)](https://github.com/OpenFreeEnergy/feflow/actions/workflows/ci.yaml)
+[![codecov](https://codecov.io/gh/OpenFreeEnergy/feflow/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenFreeEnergy/feflow/branch/main)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.13134624.svg)](https://doi.org/10.5281/zenodo.13134624)
 
 
@@ -13,6 +13,7 @@ Recipes, utilities, and protocols for molecular free energy calculations using t
 ### Copyright
 
 Copyright (c) 2023, ChoderaLab
+Copyright (c) 2024, The Open Free Energy development team
 
 
 ### Acknowledgements

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,8 +26,9 @@ project = "feflow"
 copyright = (
     "2023, ChoderaLab. Project structure based on the "
     "Computational Molecular Science Python Cookiecutter version 1.1"
+    "2024, The OpenFE Development Team."
 )
-author = "ChoderaLab"
+author = "ChoderaLab & The OpenFE Development Team"
 
 # The short X.Y version
 version = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ description = "Recipes and protocols for molecular free energy calculations usin
 dynamic = ["version"]
 readme = "README.md"
 authors = [
-    { name = "ChoderaLab", email = "ivan.pulido@choderalab.org" }
+    { name = "ChoderaLab", email = "ivan.pulido@choderalab.org" },
+    { name = "The Open Free Energy Development Team"}
 ]
 license = { text = "MIT" }
 # See https://pypi.org/classifiers/

--- a/rever.xsh
+++ b/rever.xsh
@@ -1,5 +1,5 @@
 $PROJECT = $GITHUB_REPO = 'feflow'
-$GITHUB_ORG = 'choderalab'
+$GITHUB_ORG = 'OpenFreeEnergy'
 
 $ACTIVITIES = ['changelog']
 


### PR DESCRIPTION
When we moved from the `choderalab` organization to the `OpenFreeEnergy` org, we missed changing some of the docs and references.

These set of changes set the references to the correct organization, or adds mentions to the new organization when both can coexist.

This was noted when evaluating the status for the 0.1.1 release.