### PR TITLE
Support recent openfe and pymbar versions

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -10,7 +10,7 @@ dependencies:
   - openff-units
   - openmm
   - openmmforcefields >=0.14.1  # TODO: remove when upstream deps fix this
-  - pymbar <4
+  - pymbar >4.0
   - pydantic >=1.10.17
   - python
 

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -6,7 +6,7 @@ dependencies:
     # Base depends
   - gufe >=0.9.5
   - numpy
-  - openfe >=0.15  # TODO: Remove once we don't depend on openfe
+  - openfe >=1.1.0  # TODO: Remove once we don't depend on openfe
   - openff-units
   - openmm
   - openmmforcefields >=0.14.1  # TODO: remove when upstream deps fix this

--- a/feflow/protocols/nonequilibrium_cycling.py
+++ b/feflow/protocols/nonequilibrium_cycling.py
@@ -23,7 +23,10 @@ from feflow.settings.small_molecules import OpenFFPartialChargeSettings
 
 # TODO: Remove/change when things get migrated to openmmtools or feflow
 from openfe.protocols.openmm_utils import system_creation
-from openfe.protocols.openmm_rfe._rfe_utils.compute import get_openmm_platform
+try:  # Support openfe < 1.3.0
+    from openfe.protocols.openmm_rfe._rfe_utils.compute import get_openmm_platform
+except ModuleNotFoundError:
+    from openfe.protocols.openmm_utils.omm_compute import get_openmm_platform
 
 from openff.toolkit import Molecule as OFFMolecule
 from openff.units import unit

--- a/feflow/protocols/nonequilibrium_cycling.py
+++ b/feflow/protocols/nonequilibrium_cycling.py
@@ -867,7 +867,9 @@ class NonEquilibriumCyclingProtocolResult(ProtocolResult):
 
         forward_work: npt.NDArray[float] = np.array(forward_work)
         reverse_work: npt.NDArray[float] = np.array(reverse_work)
-        free_energy, error = pymbar.bar.BAR(forward_work, reverse_work)
+        fe_bar = pymbar.bar(forward_work, reverse_work)
+        free_energy = fe_bar["Delta_f"]
+        error = fe_bar["dDelta_f"]
 
         return (
             free_energy * unit.k * self.data["temperature"] * unit.avogadro_constant
@@ -941,7 +943,9 @@ class NonEquilibriumCyclingProtocolResult(ProtocolResult):
             indices = np.random.choice(
                 np.arange(traj_size), size=[traj_size], replace=True
             )
-            dg, ddg = pymbar.bar.BAR(forward[indices], reverse[indices])
+            fe_bar = pymbar.bar(forward[indices], reverse[indices])
+            dg = fe_bar["Delta_f"]
+            ddg = fe_bar["dDelta_f"]
             all_dgs[i] = dg
 
         return all_dgs

--- a/feflow/protocols/nonequilibrium_cycling.py
+++ b/feflow/protocols/nonequilibrium_cycling.py
@@ -23,6 +23,7 @@ from feflow.settings.small_molecules import OpenFFPartialChargeSettings
 
 # TODO: Remove/change when things get migrated to openmmtools or feflow
 from openfe.protocols.openmm_utils import system_creation
+
 try:  # Support openfe < 1.3.0
     from openfe.protocols.openmm_rfe._rfe_utils.compute import get_openmm_platform
 except ModuleNotFoundError:


### PR DESCRIPTION
These changes support recent versions of openfe and pymbar. Especifically, `openfe>=1.1.0` and `pymbar>4.0`.

As far as I can tell openfe 1.1.0 changed the API so that's why I'm aiming for that one to be the minimum version we support. Especifically some of the utility changed places in latest release to date (1.3.0).

The `pymbar.bar` estimator now returns a dictionary.