### PR TITLE
ci: update to the new start and stop actions

### DIFF
--- a/.github/workflows/gpu-runner.yaml
+++ b/.github/workflows/gpu-runner.yaml
@@ -20,13 +20,10 @@ jobs:
           aws-region: us-east-2
       - name: Create cloud runner
         id: aws-start
-        uses: omsf-eco-infra/gha-runner@v0.2.0
+        uses: omsf/start-aws-gha-runner@v1.0.0
         with:
-          provider: "aws"
-          action: "start"
           aws_image_id: ami-0b7f661c228e6a4bb
           aws_instance_type: g4dn.xlarge
-          aws_region_name: us-east-2
           aws_home_dir: /home/ubuntu
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
@@ -102,11 +99,8 @@ jobs:
           role-to-assume: arn:aws:iam::010438489691:role/GHARunnerAWS
           aws-region: us-east-2
       - name: Stop instances
-        uses: omsf-eco-infra/gha-runner@v0.2.0
+        uses: omsf/stop-aws-gha-runner@v1.0.0
         with:
-          provider: "aws"
-          action: "stop"
           instance_mapping: ${{ needs.start-aws-runner.outputs.mapping }}
-          aws_region_name: us-east-2
         env:
           GH_PAT: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/gpu-runner.yaml` file to improve the management of AWS GitHub Actions runners. The key changes involve updating the actions used for starting and stopping AWS instances to newer versions. These new actions adhere to the AWS SDK such that we don't need to include the region name anymore. Additionally, these split up the actions so that they are more succinct.

Updates to AWS GitHub Actions runners:

* Updated the action used to start AWS instances from `omsf-eco-infra/gha-runner@v0.2.0` to `omsf/start-aws-gha-runner@v1.0.0` and removed unnecessary parameters. (`.github/workflows/gpu-runner.yaml`, [.github/workflows/gpu-runner.yamlL23-L29](diffhunk://#diff-0086026c407da16a8c2c0765d46e9d25b38320d39729545b00eb64ddfc5af198L23-L29))
* Updated the action used to stop AWS instances from `omsf-eco-infra/gha-runner@v0.2.0` to `omsf/stop-aws-gha-runner@v1.0.0` and removed unnecessary parameters. (`.github/workflows/gpu-runner.yaml`, [.github/workflows/gpu-runner.yamlL105-L110](diffhunk://#diff-0086026c407da16a8c2c0765d46e9d25b38320d39729545b00eb64ddfc5af198L105-L110))