### PR TITLE
Importing `FloatQuantity` from vendored model in gufe

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,9 +30,9 @@ jobs:
         os: ["ubuntu"]
         pydantic: ["1", "2"]
         python-version:
-          - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
         include:
           - os: "macos"
             python-version: "3.11"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,12 +23,11 @@ defaults:
 jobs:
   tests:
     runs-on: ${{ matrix.os }}-latest
-    name: "💻-${{matrix.os }} 🐍-${{ matrix.python-version }} - pydantic ${{matrix.pydantic}}"
+    name: "💻-${{matrix.os }} 🐍-${{ matrix.python-version }}"
     strategy:
       fail-fast: false
       matrix:
         os: ["ubuntu"]
-        pydantic: ["1", "2"]
         python-version:
           - "3.10"
           - "3.11"
@@ -53,7 +52,6 @@ jobs:
           cache-downloads: true
           create-args: >-
             python=${{ matrix.python-version }}
-            pydantic=${{ matrix.pydantic }}
           init-shell: bash
 
       - name: "Install"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,9 +30,9 @@ jobs:
         os: ["ubuntu"]
         pydantic: ["1", "2"]
         python-version:
+          - "3.10"
           - "3.11"
           - "3.12"
-          - "3.13"
         include:
           - os: "macos"
             python-version: "3.11"

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -4,7 +4,7 @@ channels:
   - openeye
 dependencies:
     # Base depends
-  - gufe >=1.3, <2
+  - gufe >=1.4, <2
   - numpy
   - openfe >=1.1.0  # TODO: Remove once we don't depend on openfe
   - openff-units

--- a/feflow/settings/integrators.py
+++ b/feflow/settings/integrators.py
@@ -9,7 +9,7 @@ for the specific integrator settings.
 from pydantic.v1 import validator
 
 from openff.units import unit
-from openff.models.types import FloatQuantity
+from gufe.vendor.openff.models.types import FloatQuantity
 from gufe.settings import SettingsBaseModel
 
 


### PR DESCRIPTION
`openff.models` has been deprecated. `gufe` has now vendored some of the models. This set of changes uses the vendored types in `gufe` instead of `openff.models`.

Note: This should fix the CI problems we have been facing lately. 