### PR TITLE
Updated changelog for 0.1.4 release

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -4,6 +4,10 @@ feflow Change Log
 
 .. current developments
 
+v0.1.4
+====================
+- Dropping use of deprecated ``openff-models``. Using vendored ``gufe`` implementation instead (`PR #123 <https://github.com/OpenFreeEnergy/feflow/pull/123>`_)
+
 v0.1.3
 ====================
 


### PR DESCRIPTION
Changelog update to prepare 0.1.4 release. 

Only changes in dropping the use of `openff-models` and instead using the `gufe` vendored implementation, as per https://github.com/OpenFreeEnergy/feflow/pull/123 