### PR TITLE
Migrate to native pydantic v2 API

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -6,7 +6,7 @@ dependencies:
     # Base depends
   - gufe ~=1.9.0
   - numpy
-  - openfe ~=1.10.0   # TODO: Remove once we don't depend on openfe
+  - openfe ~=1.8.0   # TODO: Remove once we don't depend on openfe
   - openff-units
   - openmm
   - openmmforcefields >=0.14.1  # TODO: remove when upstream deps fix this

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -4,9 +4,9 @@ channels:
   - openeye
 dependencies:
     # Base depends
-  - gufe ~=1.7.1
+  - gufe ~=1.9.1
   - numpy
-  - openfe ~=1.8.0   # TODO: Remove once we don't depend on openfe
+  - openfe ~=1.10.0   # TODO: Remove once we don't depend on openfe
   - openff-units
   - openmm
   - openmmforcefields >=0.14.1  # TODO: remove when upstream deps fix this

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -4,7 +4,7 @@ channels:
   - openeye
 dependencies:
     # Base depends
-  - gufe ~=1.9.0
+  - gufe ~=1.8.0
   - numpy
   - openfe ~=1.8.0   # TODO: Remove once we don't depend on openfe
   - openff-units

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -12,7 +12,7 @@ dependencies:
   - openmmforcefields >=0.14.1  # TODO: remove when upstream deps fix this
   - openmmtools >=0.23.0
   - pymbar ~=4.0
-  - pydantic >=1.10.17, <3
+  - pydantic >=2
   - python
     # Testing (optional deps)
   - espaloma_charge ==0.0.8  # To use Espaloma FF in tests

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -4,7 +4,7 @@ channels:
   - openeye
 dependencies:
     # Base depends
-  - gufe ~=1.9.1
+  - gufe ~=1.9.0
   - numpy
   - openfe ~=1.10.0   # TODO: Remove once we don't depend on openfe
   - openff-units

--- a/docs/tutorials/protein-mutations-neq.ipynb
+++ b/docs/tutorials/protein-mutations-neq.ipynb
@@ -304,18 +304,7 @@
    "execution_count": 10,
    "id": "bdd9ddc5-42fb-4fd9-9517-54a1d16e1c9d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ijpulidos/miniforge3/envs/feflow-dev/lib/python3.12/site-packages/pydantic/_internal/_config.py:323: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/\n",
-      "  warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)\n",
-      "/home/ijpulidos/miniforge3/envs/feflow-dev/lib/python3.12/site-packages/pydantic/_internal/_config.py:323: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/\n",
-      "  warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from feflow.protocols import NonEquilibriumCyclingProtocol\n",
     "from openff.units import unit\n",

--- a/feflow/settings/integrators.py
+++ b/feflow/settings/integrators.py
@@ -8,7 +8,7 @@ for the specific integrator settings.
 
 from typing import Annotated, TypeAlias
 
-from pydantic.v1 import validator
+from pydantic import ConfigDict, field_validator
 
 from openff.units import unit
 from gufe.settings import SettingsBaseModel
@@ -25,8 +25,7 @@ TimestepQuantity: TypeAlias = Annotated[
 class PeriodicNonequilibriumIntegratorSettings(SettingsBaseModel):
     """Settings for the PeriodicNonequilibriumIntegrator"""
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     timestep: FemtosecondQuantity = 4 * unit.femtoseconds
     """Size of the simulation timestep. Default 4 fs."""
@@ -48,7 +47,8 @@ class PeriodicNonequilibriumIntegratorSettings(SettingsBaseModel):
     """
 
     # TODO: This validator is used in other settings, better create a new Type
-    @validator("timestep")
+    @field_validator("timestep")
+    @classmethod
     def must_be_positive(cls, v):
         if v <= 0:
             errmsg = f"timestep must be positive, received {v}."
@@ -56,7 +56,8 @@ class PeriodicNonequilibriumIntegratorSettings(SettingsBaseModel):
         return v
 
     # TODO: This validator is used in other settings, better create a new Type
-    @validator("timestep")
+    @field_validator("timestep")
+    @classmethod
     def is_time(cls, v):
         # these are time units, not simulation steps
         if not v.is_compatible_with(unit.picosecond):
@@ -64,7 +65,8 @@ class PeriodicNonequilibriumIntegratorSettings(SettingsBaseModel):
         return v
 
     # TODO: This validator is used in other settings, better create a new Type
-    @validator("equilibrium_steps", "nonequilibrium_steps")
+    @field_validator("equilibrium_steps", "nonequilibrium_steps")
+    @classmethod
     def must_be_positive_or_zero(cls, v):
         if v < 0:
             errmsg = (

--- a/feflow/settings/nonequilibrium_cycling.py
+++ b/feflow/settings/nonequilibrium_cycling.py
@@ -89,14 +89,13 @@ class NonEquilibriumCyclingSettings(Settings):
     store_minimized_pdb: bool = True
     """Setting for storing pdb right after minimization (right before neq cycle)"""
 
-    @model_validator(mode="before")
-    @classmethod
-    def save_frequencies_consistency(cls, values):
+    @model_validator(mode="after")
+    def save_frequencies_consistency(self):
         """Checks trajectory save frequency is a multiple of work save frequency, for convenience"""
-        if values.get("traj_save_frequency") % values.get("work_save_frequency") != 0:
+        if self.traj_save_frequency % self.work_save_frequency != 0:
             raise ValueError(
                 "Work save frequency must be a divisor of trajectory save frequency. "
                 "Please specify consistent values for trajectory and work save settings"
             )
         # TODO: Add check for eq and neq steps and save frequencies
-        return values
+        return self

--- a/feflow/settings/nonequilibrium_cycling.py
+++ b/feflow/settings/nonequilibrium_cycling.py
@@ -10,7 +10,7 @@ from feflow.settings import (
 )
 
 from gufe.settings import Settings, OpenMMSystemGeneratorFFSettings
-from pydantic.v1 import root_validator
+from pydantic import ConfigDict, model_validator
 from openfe.protocols.openmm_utils.omm_settings import (
     OpenMMSolvationSettings,
     OpenMMEngineSettings,
@@ -53,8 +53,7 @@ class NonEquilibriumCyclingSettings(Settings):
     """
 
     # TODO: Add type hints
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     forcefield_cache: Optional[str] = (
         "db.json"  # TODO: Remove once it has been integrated with openfe settings
@@ -90,7 +89,8 @@ class NonEquilibriumCyclingSettings(Settings):
     store_minimized_pdb: bool = True
     """Setting for storing pdb right after minimization (right before neq cycle)"""
 
-    @root_validator
+    @model_validator(mode="before")
+    @classmethod
     def save_frequencies_consistency(cls, values):
         """Checks trajectory save frequency is a multiple of work save frequency, for convenience"""
         if values.get("traj_save_frequency") % values.get("work_save_frequency") != 0:


### PR DESCRIPTION
## Summary
- Replace `pydantic.v1` compat imports with native `pydantic` v2 API (`field_validator`, `model_validator`, `ConfigDict`)
- Tighten pydantic dependency to `>=2`
- Remove pydantic deprecation warnings from tutorial notebook

Closes #131

🤖 Generated with [Claude Code](https://claude.ai/claude-code)