### PR TITLE
Added `setup_minimize` setting for `NonEquilibriumCyclingProtocol`

### DIFF
--- a/feflow/protocols/nonequilibrium_cycling.py
+++ b/feflow/protocols/nonequilibrium_cycling.py
@@ -329,18 +329,19 @@ class SetupUnit(ProtocolUnit):
 
         try:
             # Minimize
-            openmm.LocalEnergyMinimizer.minimize(context)
-            # Optionally store minimized topology -- Mostly for debugging purposes
-            if settings.store_minimized_pdb:
-                from openmm.app import PDBFile
+            if settings.setup_minimize:
+                openmm.LocalEnergyMinimizer.minimize(context)
+                # Optionally store minimized topology -- Mostly for debugging purposes
+                if settings.store_minimized_pdb:
+                    from openmm.app import PDBFile
 
-                omm_top_ = hybrid_factory.omm_hybrid_topology
-                omm_state_ = context.getState(getPositions=True)
-                omm_pos_ = omm_state_.getPositions()
-                with open(
-                    ctx.shared / "minimized_hybrid_topology.pdb", "w"
-                ) as out_file:
-                    PDBFile.writeFile(omm_top_, omm_pos_, out_file)
+                    omm_top_ = hybrid_factory.omm_hybrid_topology
+                    omm_state_ = context.getState(getPositions=True)
+                    omm_pos_ = omm_state_.getPositions()
+                    with open(
+                        ctx.shared / "minimized_hybrid_topology.pdb", "w"
+                    ) as out_file:
+                        PDBFile.writeFile(omm_top_, omm_pos_, out_file)
 
             # SERIALIZE SYSTEM, STATE, INTEGRATOR
             # need to set velocities to temperature so serialized state features velocities,

--- a/feflow/settings/nonequilibrium_cycling.py
+++ b/feflow/settings/nonequilibrium_cycling.py
@@ -85,7 +85,9 @@ class NonEquilibriumCyclingSettings(Settings):
 
     num_cycles: int = 100  # Number of cycles to run
 
-    setup_minimize: bool = True # If True, minimize the system in the SetupUnit; we don't want to do this on platforms like Folding@Home
+    setup_minimize: bool = (
+        True  # If True, minimize the system in the SetupUnit; we don't want to do this on platforms like Folding@Home
+    )
 
     # Debugging settings
     store_minimized_pdb: bool = True

--- a/feflow/settings/nonequilibrium_cycling.py
+++ b/feflow/settings/nonequilibrium_cycling.py
@@ -103,3 +103,14 @@ class NonEquilibriumCyclingSettings(Settings):
             )
         # TODO: Add check for eq and neq steps and save frequencies
         return self
+
+    @model_validator(mode="after")
+    def store_minimized_pdb_requires_setup_minimize(self):
+        """Storing the minimized PDB requires minimization to be enabled."""
+        if self.store_minimized_pdb and not self.setup_minimize:
+            raise ValueError(
+                "`store_minimized_pdb` requires `setup_minimize` to be True, "
+                "since there is no minimized structure to store when minimization "
+                "is disabled."
+            )
+        return self

--- a/feflow/settings/nonequilibrium_cycling.py
+++ b/feflow/settings/nonequilibrium_cycling.py
@@ -85,6 +85,8 @@ class NonEquilibriumCyclingSettings(Settings):
 
     num_cycles: int = 100  # Number of cycles to run
 
+    setup_minimize: bool = True # If True, minimize the system in the SetupUnit; we don't want to do this on platforms like Folding@Home
+
     # Debugging settings
     store_minimized_pdb: bool = True
     """Setting for storing pdb right after minimization (right before neq cycle)"""

--- a/feflow/tests/test_nonequilibrium_cycling.py
+++ b/feflow/tests/test_nonequilibrium_cycling.py
@@ -801,3 +801,21 @@ def test_settings_round_trip():
         json.loads(neq_json, cls=JSON_HANDLER.decoder)
     )
     assert neq_settings == neq_settings_2
+
+
+def test_store_minimized_pdb_requires_setup_minimize():
+    """
+    ``store_minimized_pdb`` requires ``setup_minimize`` to be True, since there
+    is no minimized structure to store when minimization is disabled.
+    """
+    settings = NonEquilibriumCyclingProtocol.default_settings()
+
+    # Disabling minimization while keeping ``store_minimized_pdb`` should raise
+    with pytest.raises(ValueError, match="store_minimized_pdb"):
+        settings.setup_minimize = False
+
+    # Disabling both is valid
+    settings.store_minimized_pdb = False
+    settings.setup_minimize = False
+    assert not settings.setup_minimize
+    assert not settings.store_minimized_pdb


### PR DESCRIPTION
This setting allows a user (or subclass of this protocol) to switch off minimization in the `SetupUnit`. This is valuable for Folding@Home use with the `FahNonEquilibriumCyclingProtocol` in `alchemiscale-fah`, since we don't want to perform costly CPU minimizations on the work server where the `SetupUnit` is run.
